### PR TITLE
Change the formula cat-gate uses to schedule pods

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cybozu-go/cat-gate/hooks"
 	"github.com/cybozu-go/cat-gate/internal/controller"
 	"github.com/cybozu-go/cat-gate/internal/indexing"
+	"github.com/cybozu-go/cat-gate/internal/runners"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -113,6 +114,11 @@ func main() {
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder
+
+	if err = mgr.Add(runners.GarbageCollector{}); err != nil {
+		setupLog.Error(err, "unable to add garbage collector")
+		os.Exit(1)
+	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -27,7 +27,7 @@ setup:
 	mkdir -p $(BIN_DIR)
 	$(CURL) -o $(BIN_DIR)/kubectl https://storage.googleapis.com/kubernetes-release/release/v$(E2ETEST_K8S_VERSION)/bin/linux/amd64/kubectl && chmod a+x $(BIN_DIR)/kubectl
 	# TODO: specify kind version
-    GOBIN=$(BIN_DIR) go install sigs.k8s.io/kind@latest
+	GOBIN=$(BIN_DIR) go install sigs.k8s.io/kind@latest
 
 .PHONY: start
 start:

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -6,3 +6,6 @@ const PodSchedulingGateName = MetaPrefix + "gate"
 const CatGateImagesHashAnnotation = MetaPrefix + "images-hash"
 
 const ImageHashAnnotationField = ".metadata.annotations.images-hash"
+
+const LevelWarning = 1
+const LevelDebug = -1

--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -86,7 +86,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	// prevents removing the scheduling gate based on information before the cache is updated.
 	if value, ok := GateRemovalHistories.Load(reqImagesHash); ok {
-		lastGateRemovalTime := time.UnixMilli(value.(int64))
+		lastGateRemovalTime := value.(time.Time)
 		if time.Since(lastGateRemovalTime) < time.Duration(gateRemovalDelayMilliSecond)*time.Millisecond {
 			logger.V(constants.LevelDebug).Info("perform retry processing to avoid race conditions", "lastGateRemovalTime", lastGateRemovalTime)
 			return ctrl.Result{RequeueAfter: time.Duration(gateRemovalDelayMilliSecond) * time.Millisecond}, nil
@@ -181,7 +181,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			logger.Error(err, "failed to remove scheduling gate")
 			return ctrl.Result{}, err
 		}
-		now := time.Now().UnixMilli()
+		now := time.Now()
 		GateRemovalHistories.Store(reqImagesHash, now)
 		return ctrl.Result{}, nil
 	}

--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -87,9 +87,9 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	// prevents removing the scheduling gate based on information before the cache is updated.
 	if value, ok := GateRemovalHistories.Load(reqImagesHash); ok {
 		lastGateRemovalTime := time.UnixMilli(value.(int64))
-		if time.Since(lastGateRemovalTime) < time.Millisecond*time.Duration(gateRemovalDelayMilliSecond) {
+		if time.Since(lastGateRemovalTime) < time.Duration(gateRemovalDelayMilliSecond)*time.Millisecond {
 			logger.V(constants.LevelDebug).Info("perform retry processing to avoid race conditions", "lastGateRemovalTime", lastGateRemovalTime)
-			return ctrl.Result{RequeueAfter: time.Millisecond * time.Duration(gateRemovalDelayMilliSecond)}, nil
+			return ctrl.Result{RequeueAfter: time.Duration(gateRemovalDelayMilliSecond) * time.Millisecond}, nil
 		}
 	}
 
@@ -187,7 +187,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	return ctrl.Result{
-		RequeueAfter: time.Second * time.Duration(requeueSeconds),
+		RequeueAfter: time.Duration(requeueSeconds) * time.Second,
 	}, nil
 }
 

--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -151,16 +151,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 		numSchedulablePods += 1
 
-		allStarted := true
-		statuses := pod.Status.ContainerStatuses
-		for _, status := range statuses {
-			if status.State.Running == nil && status.State.Terminated == nil {
-				allStarted = false
-				break
-			}
-		}
-
-		if allStarted && len(pod.Spec.Containers) == len(statuses) {
+		if pod.Status.Phase != corev1.PodPending {
 			numImagePulledPods += 1
 		}
 	}

--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -94,6 +94,12 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	var reqImageList []string
+	for _, initContainer := range reqPod.Spec.InitContainers {
+		if initContainer.Image == "" {
+			continue
+		}
+		reqImageList = append(reqImageList, initContainer.Image)
+	}
 	for _, container := range reqPod.Spec.Containers {
 		if container.Image == "" {
 			continue

--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -44,9 +44,6 @@ const scaleRate = 2
 // minimumCapacity the number of scheduling gates to remove when no node have the image.
 const minimumCapacity = 1
 
-const levelWarning = 1
-const levelDebug = -1
-
 var requeueSeconds = 10
 var gateRemovalDelayMilliSecond = 10
 var GateRemovalHistories = sync.Map{}
@@ -77,7 +74,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	annotations := reqPod.Annotations
 	if _, ok := annotations[constants.CatGateImagesHashAnnotation]; !ok {
-		logger.V(levelWarning).Info("pod annotation not found")
+		logger.V(constants.LevelWarning).Info("pod annotation not found")
 		err := r.removeSchedulingGate(ctx, reqPod)
 		if err != nil {
 			logger.Error(err, "failed to remove scheduling gate")
@@ -91,7 +88,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	if value, ok := GateRemovalHistories.Load(reqImagesHash); ok {
 		lastGateRemovalTime := time.UnixMilli(value.(int64))
 		if time.Since(lastGateRemovalTime) < time.Millisecond*time.Duration(gateRemovalDelayMilliSecond) {
-			logger.V(levelDebug).Info("perform retry processing to avoid race conditions", "lastGateRemovalTime", lastGateRemovalTime)
+			logger.V(constants.LevelDebug).Info("perform retry processing to avoid race conditions", "lastGateRemovalTime", lastGateRemovalTime)
 			return ctrl.Result{RequeueAfter: time.Millisecond * time.Duration(gateRemovalDelayMilliSecond)}, nil
 		}
 	}
@@ -167,10 +164,10 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	if capacity < minimumCapacity {
 		capacity = minimumCapacity
 	}
-	logger.V(levelDebug).Info("schedule capacity", "capacity", capacity, "len(nodeSet)", len(nodeSet))
+	logger.V(constants.LevelDebug).Info("schedule capacity", "capacity", capacity, "len(nodeSet)", len(nodeSet))
 
 	numImagePullingPods := numSchedulablePods - numImagePulledPods
-	logger.V(levelDebug).Info("scheduling progress", "numSchedulablePods", numSchedulablePods, "numImagePulledPods", numImagePulledPods, "numImagePullingPods", numImagePullingPods)
+	logger.V(constants.LevelDebug).Info("scheduling progress", "numSchedulablePods", numSchedulablePods, "numImagePulledPods", numImagePulledPods, "numImagePullingPods", numImagePullingPods)
 
 	if capacity > numImagePullingPods {
 		err := r.removeSchedulingGate(ctx, reqPod)

--- a/internal/controller/pod_controller_test.go
+++ b/internal/controller/pod_controller_test.go
@@ -343,8 +343,8 @@ var _ = Describe("CatGate controller", func() {
 		Expect(err).NotTo(HaveOccurred())
 		for _, node := range nodes.Items {
 			updateNodeImageStatus(&node, []corev1.Container{
-				{Image: fmt.Sprintf("%s.example.com/sample1-image:1.0.0", testName)},
-				{Image: fmt.Sprintf("%s.example.com/sample2-image:1.0.0", testName)},
+				{Image: fmt.Sprintf("%s.example.com/sample1-image:1.0.0", testName)}, // init container image
+				{Image: fmt.Sprintf("%s.example.com/sample2-image:1.0.0", testName)}, // container image
 			})
 		}
 
@@ -417,6 +417,7 @@ func scheduleAndStartPods(namespace string) {
 			node := &corev1.Node{}
 			err = k8sClient.Get(ctx, client.ObjectKey{Name: pod.Status.HostIP}, node)
 			Expect(err).NotTo(HaveOccurred())
+			updateNodeImageStatus(node, pod.Spec.InitContainers)
 			updateNodeImageStatus(node, pod.Spec.Containers)
 		}
 	}
@@ -434,6 +435,7 @@ func scheduleAndStartOnePod(namespace string) {
 			node := &corev1.Node{}
 			err = k8sClient.Get(ctx, client.ObjectKey{Name: pod.Status.HostIP}, node)
 			Expect(err).NotTo(HaveOccurred())
+			updateNodeImageStatus(node, pod.Spec.InitContainers)
 			updateNodeImageStatus(node, pod.Spec.Containers)
 			break
 		}
@@ -451,6 +453,7 @@ func scheduleSpecificNodeAndStartOnePod(namespace, nodeName string) {
 			node := &corev1.Node{}
 			err = k8sClient.Get(ctx, client.ObjectKey{Name: pod.Status.HostIP}, node)
 			Expect(err).NotTo(HaveOccurred())
+			updateNodeImageStatus(node, pod.Spec.InitContainers)
 			updateNodeImageStatus(node, pod.Spec.Containers)
 			break
 		}
@@ -468,6 +471,7 @@ func scheduleAndStartOneUnhealthyPod(namespace string) {
 			node := &corev1.Node{}
 			err = k8sClient.Get(ctx, client.ObjectKey{Name: pod.Status.HostIP}, node)
 			Expect(err).NotTo(HaveOccurred())
+			updateNodeImageStatus(node, pod.Spec.InitContainers)
 			updateNodeImageStatus(node, pod.Spec.Containers)
 			break
 		}

--- a/internal/controller/pod_controller_test.go
+++ b/internal/controller/pod_controller_test.go
@@ -92,7 +92,7 @@ var _ = Describe("CatGate controller", func() {
 					numSchedulable += 1
 				}
 			}
-			// no pod is already running, so 1 pods should be scheduled
+			// no nodes with images exist, so 1 pods should be scheduled
 			g.Expect(numSchedulable).To(Equal(1))
 		}).Should(Succeed())
 		scheduleAndStartPods(testName)
@@ -106,7 +106,7 @@ var _ = Describe("CatGate controller", func() {
 					numSchedulable += 1
 				}
 			}
-			// 1 pod is already running, so 3(1 + 1*2) pods should be scheduled
+			// several images exist on 1 node, so 3(1 + 1*2) pods should be scheduled
 			g.Expect(numSchedulable).To(Equal(3))
 		}).Should(Succeed())
 		scheduleAndStartPods(testName)
@@ -120,7 +120,7 @@ var _ = Describe("CatGate controller", func() {
 					numSchedulable += 1
 				}
 			}
-			// 3 pods are already running, so 9 (3 + 3*2) pods should be scheduled
+			// several images exist on 3 node, so 9 (3 + 3*2) pods should be scheduled
 			g.Expect(numSchedulable).To(Equal(9))
 		}).Should(Succeed())
 	})
@@ -181,7 +181,7 @@ var _ = Describe("CatGate controller", func() {
 					numSchedulable += 1
 				}
 			}
-			// no pod is already running, so 1 pods should be scheduled
+			// no nodes with images exist, so 1 pods should be scheduled
 			g.Expect(numSchedulable).To(Equal(1))
 		}).Should(Succeed())
 		scheduleAndStartPods(testName)
@@ -195,7 +195,7 @@ var _ = Describe("CatGate controller", func() {
 					numSchedulable += 1
 				}
 			}
-			// 1 pod is already running, so 3(1 + 1*2) pods should be scheduled
+			// several images exist on 1 node, so 3(1 + 1*2) pods should be scheduled
 			g.Expect(numSchedulable).To(Equal(3))
 		}).Should(Succeed())
 		scheduleAndStartOnePod(testName)
@@ -209,7 +209,7 @@ var _ = Describe("CatGate controller", func() {
 					numSchedulable += 1
 				}
 			}
-			// 2 pods are already running, so 6 (2 + 2*2) pods should be scheduled
+			// several images exist on 2 node, so 6 (2 + 2*2) pods should be scheduled
 			g.Expect(numSchedulable).To(Equal(6))
 		}).Should(Succeed())
 	})
@@ -245,7 +245,7 @@ var _ = Describe("CatGate controller", func() {
 					numSchedulable += 1
 				}
 			}
-			// no pod is already running, so 1 pods should be scheduled
+			// no nodes with images exist, so 1 pods should be scheduled
 			g.Expect(numSchedulable).To(Equal(1))
 		}).Should(Succeed())
 		scheduleSpecificNodeAndStartOnePod(testName, nodes.Items[0].Name)
@@ -259,7 +259,7 @@ var _ = Describe("CatGate controller", func() {
 					numSchedulable += 1
 				}
 			}
-			// 1 pod is already running, so 3(1 + 1*2) pods should be scheduled
+			// several images exist on 1 node, so 3(1 + 1*2) pods should be scheduled
 			g.Expect(numSchedulable).To(Equal(3))
 		}).Should(Succeed())
 		scheduleSpecificNodeAndStartOnePod(testName, nodes.Items[0].Name)
@@ -273,14 +273,14 @@ var _ = Describe("CatGate controller", func() {
 					numSchedulable += 1
 				}
 			}
-			// 2 pods are already running on a same node, so 3 pods should be scheduled
+			// several images exist on 1 node, so 3(1 + 1*2) pods should be scheduled.
+			// as there is only 1 node, it is not possible to schedule more pods than capacity.
 			g.Expect(numSchedulable).To(Equal(3))
 		}).Should(Succeed())
-
 	})
 
 	It("Should the schedule not increase if the pod is not Running", func() {
-		testName := "crash-pod"
+		testName := "no-start-pod"
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testName,
@@ -291,8 +291,6 @@ var _ = Describe("CatGate controller", func() {
 
 		for i := 0; i < 3; i++ {
 			createNewPod(testName, i)
-		}
-		for i := 0; i < 3; i++ {
 			createNewNode(testName, i)
 		}
 
@@ -306,7 +304,7 @@ var _ = Describe("CatGate controller", func() {
 					numSchedulable += 1
 				}
 			}
-			// no pod is already running, so 1 pods should be scheduled
+			// no nodes with images exist, so 1 pods should be scheduled
 			g.Expect(numSchedulable).To(Equal(1))
 		}).Should(Succeed())
 		scheduleAndStartOneUnhealthyPod(testName)
@@ -320,8 +318,52 @@ var _ = Describe("CatGate controller", func() {
 					numSchedulable += 1
 				}
 			}
-			// 1 pod is already scheduled, but it is not running, so 1 pod should be scheduled
-			g.Expect(numSchedulable).To(Equal(1))
+			// 1 pod is already scheduled, but it is not running,
+			// so 2(capacity: 2, numImagePullingPods: 2) pod should be scheduled
+			g.Expect(numSchedulable).To(Equal(2))
+		}).Should(Succeed())
+	})
+
+	It("Should more Pods be scheduled if images are present in a node, not limited to the number of Pods.", func() {
+		testName := "already-images-in-node"
+		namespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testName,
+			},
+		}
+		err := k8sClient.Create(ctx, namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		for i := 0; i < 10; i++ {
+			createNewNode(testName, i)
+		}
+
+		nodes := &corev1.NodeList{}
+		err = k8sClient.List(ctx, nodes)
+		Expect(err).NotTo(HaveOccurred())
+		for _, node := range nodes.Items {
+			updateNodeImageStatus(&node, []corev1.Container{
+				{Image: fmt.Sprintf("%s.example.com/sample1-image:1.0.0", testName)},
+				{Image: fmt.Sprintf("%s.example.com/sample2-image:1.0.0", testName)},
+			})
+		}
+
+		for i := 0; i < 10; i++ {
+			createNewPod(testName, i)
+		}
+
+		pods := &corev1.PodList{}
+		Eventually(func(g Gomega) {
+			err := k8sClient.List(ctx, pods, &client.ListOptions{Namespace: testName})
+			g.Expect(err).NotTo(HaveOccurred())
+			numSchedulable := 0
+			for _, pod := range pods.Items {
+				if !existsSchedulingGate(&pod) {
+					numSchedulable += 1
+				}
+			}
+			// image is present in the node, so 10 pods should be scheduled
+			g.Expect(numSchedulable).To(Equal(10))
 		}).Should(Succeed())
 	})
 })
@@ -423,7 +465,6 @@ func scheduleAndStartOneUnhealthyPod(namespace string) {
 	for _, pod := range pods.Items {
 		if !existsSchedulingGate(&pod) && len(pod.Status.ContainerStatuses) == 0 {
 			updatePodStatus(&pod, corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "RunContainerError"}})
-
 			node := &corev1.Node{}
 			err = k8sClient.Get(ctx, client.ObjectKey{Name: pod.Status.HostIP}, node)
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/pod_controller_test.go
+++ b/internal/controller/pod_controller_test.go
@@ -348,7 +348,7 @@ var _ = Describe("CatGate controller", func() {
 			})
 		}
 
-		for i := 0; i < 10; i++ {
+		for i := 0; i < 20; i++ {
 			createNewPod(testName, i)
 		}
 
@@ -362,8 +362,8 @@ var _ = Describe("CatGate controller", func() {
 					numSchedulable += 1
 				}
 			}
-			// image is present in the node, so 10 pods should be scheduled
-			g.Expect(numSchedulable).To(Equal(10))
+			// image is present in the node, so 20 pods should be scheduled
+			g.Expect(numSchedulable).To(Equal(20))
 		}).Should(Succeed())
 	})
 })

--- a/internal/controller/pod_controller_test.go
+++ b/internal/controller/pod_controller_test.go
@@ -324,7 +324,7 @@ var _ = Describe("CatGate controller", func() {
 		}).Should(Succeed())
 	})
 
-	It("Should more Pods be scheduled if images are present in a node, not limited to the number of Pods.", func() {
+	It("Should more Pods be scheduled if images are present in all nodes, not limited to the number of Pods.", func() {
 		testName := "already-images-in-node"
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/runners/garbage_collector.go
+++ b/internal/runners/garbage_collector.go
@@ -31,7 +31,7 @@ func (gc GarbageCollector) Start(ctx context.Context) error {
 			return nil
 		case <-ticker.C:
 			controller.GateRemovalHistories.Range(func(imageHash, value interface{}) bool {
-				lastGateRemovalTime := time.UnixMilli(value.(int64))
+				lastGateRemovalTime := value.(time.Time)
 				// Delete history that has not been updated for a long time to prevent memory leaks.
 				if time.Since(lastGateRemovalTime) > time.Duration(historyDeletionDuration)*time.Second {
 					logger.V(constants.LevelDebug).Info("delete old history", "image hash", imageHash, "lastGateRemovalTime", lastGateRemovalTime)

--- a/internal/runners/garbage_collector.go
+++ b/internal/runners/garbage_collector.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"time"
 
+	"github.com/cybozu-go/cat-gate/internal/constants"
 	"github.com/cybozu-go/cat-gate/internal/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const levelDebug = -1
 const gcIntervalHours = 24
 
 var historyDeletionDuration = 24 * 60 * 60 // 1 day
@@ -34,7 +34,7 @@ func (gc GarbageCollector) Start(ctx context.Context) error {
 				lastGateRemovalTime := time.UnixMilli(value.(int64))
 				// Delete history that has not been updated for a long time to prevent memory leaks.
 				if time.Since(lastGateRemovalTime) > time.Second*time.Duration(historyDeletionDuration) {
-					logger.V(levelDebug).Info("delete old history", "image hash", imageHash, "lastGateRemovalTime", lastGateRemovalTime)
+					logger.V(constants.LevelDebug).Info("delete old history", "image hash", imageHash, "lastGateRemovalTime", lastGateRemovalTime)
 					controller.GateRemovalHistories.Delete(imageHash)
 				}
 				return true

--- a/internal/runners/garbage_collector.go
+++ b/internal/runners/garbage_collector.go
@@ -33,7 +33,7 @@ func (gc GarbageCollector) Start(ctx context.Context) error {
 			controller.GateRemovalHistories.Range(func(imageHash, value interface{}) bool {
 				lastGateRemovalTime := time.UnixMilli(value.(int64))
 				// Delete history that has not been updated for a long time to prevent memory leaks.
-				if time.Since(lastGateRemovalTime) > time.Second*time.Duration(historyDeletionDuration) {
+				if time.Since(lastGateRemovalTime) > time.Duration(historyDeletionDuration)*time.Second {
 					logger.V(constants.LevelDebug).Info("delete old history", "image hash", imageHash, "lastGateRemovalTime", lastGateRemovalTime)
 					controller.GateRemovalHistories.Delete(imageHash)
 				}

--- a/internal/runners/garbage_collector.go
+++ b/internal/runners/garbage_collector.go
@@ -1,0 +1,44 @@
+package runners
+
+import (
+	"context"
+	"time"
+
+	"github.com/cybozu-go/cat-gate/internal/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const levelDebug = -1
+const gcIntervalHours = 24
+
+var historyDeletionDuration = 24 * 60 * 60 // 1 day
+
+type GarbageCollector struct {
+}
+
+func (gc GarbageCollector) NeedLeaderElection() bool {
+	return true
+}
+
+func (gc GarbageCollector) Start(ctx context.Context) error {
+	ticker := time.NewTicker(time.Hour * gcIntervalHours)
+	defer ticker.Stop()
+	logger := log.FromContext(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			controller.GateRemovalHistories.Range(func(imageHash, value interface{}) bool {
+				lastGateRemovalTime := time.UnixMilli(value.(int64))
+				// Delete history that has not been updated for a long time to prevent memory leaks.
+				if time.Since(lastGateRemovalTime) > time.Second*time.Duration(historyDeletionDuration) {
+					logger.V(levelDebug).Info("delete old history", "image hash", imageHash, "lastGateRemovalTime", lastGateRemovalTime)
+					controller.GateRemovalHistories.Delete(imageHash)
+				}
+				return true
+			})
+		}
+	}
+}


### PR DESCRIPTION
- Change the formula cat-gate uses to schedule pods
  - Change 'Number of nodes with pods on which the container status is Running or Terminated' to 'Use the number of nodes with container images'.
- Modify the implementation to avoid requeueing when the scheduling gate is successfully removed.
- Add a process to prevent removing the scheduling gate for other Pods immediately after removing the scheduling gate, in order to prevent race conditions.